### PR TITLE
fix module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/heiyeluren/xmm
+module github.com/heiyeluren/XMM
 
 go 1.12
 


### PR DESCRIPTION
can't use `go get github.com/heiyeluren/XMM` to  download code,but the repository name is difference